### PR TITLE
feat: update room settings

### DIFF
--- a/packages/api/src/rooms/dtos/update-room-settings.request.dto.ts
+++ b/packages/api/src/rooms/dtos/update-room-settings.request.dto.ts
@@ -1,0 +1,6 @@
+import { UpdateRoomSettingsRequestSchema } from '@/contract/rooms/update-room-settings.request.dto';
+import { createZodDto } from '@anatine/zod-nestjs';
+
+export class UpdateRoomSettingsRequestDto extends createZodDto(
+  UpdateRoomSettingsRequestSchema
+) {}

--- a/packages/api/src/rooms/exceptions/no-room-settings-defined.exception.ts
+++ b/packages/api/src/rooms/exceptions/no-room-settings-defined.exception.ts
@@ -1,0 +1,36 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export const NoRoomSettingsDefinedExceptionSchema = {
+  type: 'object',
+  properties: {
+    statusCode: {
+      type: 'number',
+      example: 400,
+    },
+    message: {
+      type: 'array',
+      items: {
+        type: 'string',
+        example: 'room: no_changes',
+      },
+    },
+    error: {
+      type: 'string',
+      example: 'No settings were changed',
+    },
+  },
+  required: ['statusCode', 'message', 'error'],
+};
+
+export class NoRoomSettingsDefinedException extends HttpException {
+  constructor() {
+    super(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ['room: no_changes'],
+        error: 'No settings were changed',
+      },
+      HttpStatus.BAD_REQUEST
+    );
+  }
+}

--- a/packages/api/src/rooms/exceptions/not-room-owner.exception.ts
+++ b/packages/api/src/rooms/exceptions/not-room-owner.exception.ts
@@ -1,0 +1,36 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export const NotRoomOwnerExceptionSchema = {
+  type: 'object',
+  properties: {
+    statusCode: {
+      type: 'number',
+      example: 403,
+    },
+    message: {
+      type: 'array',
+      items: {
+        type: 'string',
+        example: 'room: not_owner',
+      },
+    },
+    error: {
+      type: 'string',
+      example: 'Only a room owner can edit its settings',
+    },
+  },
+  required: ['statusCode', 'message', 'error'],
+};
+
+export class NotRoomOwnerException extends HttpException {
+  constructor() {
+    super(
+      {
+        statusCode: HttpStatus.FORBIDDEN,
+        message: ['room: not_owner'],
+        error: 'Only a room owner can edit its settings',
+      },
+      HttpStatus.FORBIDDEN
+    );
+  }
+}

--- a/packages/api/src/rooms/rooms.controller.ts
+++ b/packages/api/src/rooms/rooms.controller.ts
@@ -7,10 +7,7 @@ import { LeaveRoomRequestDto } from '@/rooms/dtos/leave-room.request.dto';
 import { RoomResponseDto } from '@/rooms/dtos/room.response.dto';
 import { UpdateRoomSettingsRequestDto } from '@/rooms/dtos/update-room-settings.request.dto';
 import { DuplicateRoomNameExceptionSchema } from '@/rooms/exceptions/duplicate-room-name.exception';
-import {
-  NoRoomSettingsDefinedException,
-  NoRoomSettingsDefinedExceptionSchema,
-} from '@/rooms/exceptions/no-room-settings-defined.exception';
+import { NoRoomSettingsDefinedExceptionSchema } from '@/rooms/exceptions/no-room-settings-defined.exception';
 import { NotRoomOwnerExceptionSchema } from '@/rooms/exceptions/not-room-owner.exception';
 import { OwnerCannotLeaveRoomExceptionSchema } from '@/rooms/exceptions/owner-cannot-leave-room.exception';
 import { OwnerMustBeLoggedExceptionSchema } from '@/rooms/exceptions/owner-must-be-logged.exception';

--- a/packages/api/src/rooms/rooms.controller.ts
+++ b/packages/api/src/rooms/rooms.controller.ts
@@ -5,7 +5,13 @@ import { CreateRoomRequestDto } from '@/rooms/dtos/create-room.request.dto';
 import { InviteUserToRoomRequestDto } from '@/rooms/dtos/invite-user-to-room.request.dto';
 import { LeaveRoomRequestDto } from '@/rooms/dtos/leave-room.request.dto';
 import { RoomResponseDto } from '@/rooms/dtos/room.response.dto';
+import { UpdateRoomSettingsRequestDto } from '@/rooms/dtos/update-room-settings.request.dto';
 import { DuplicateRoomNameExceptionSchema } from '@/rooms/exceptions/duplicate-room-name.exception';
+import {
+  NoRoomSettingsDefinedException,
+  NoRoomSettingsDefinedExceptionSchema,
+} from '@/rooms/exceptions/no-room-settings-defined.exception';
+import { NotRoomOwnerExceptionSchema } from '@/rooms/exceptions/not-room-owner.exception';
 import { OwnerCannotLeaveRoomExceptionSchema } from '@/rooms/exceptions/owner-cannot-leave-room.exception';
 import { OwnerMustBeLoggedExceptionSchema } from '@/rooms/exceptions/owner-must-be-logged.exception';
 import { RoomNotFoundExceptionSchema } from '@/rooms/exceptions/room-not-found.exception';
@@ -14,10 +20,13 @@ import { FindMyRoomsUsecase } from '@/rooms/usecases/find-my-rooms.usecase';
 import { FindPublicRoomsUsecase } from '@/rooms/usecases/find-public-rooms.usecase';
 import { InviteUserToRoomUsecase } from '@/rooms/usecases/invite-user-to-room.usecase';
 import { LeaveRoomUsecase } from '@/rooms/usecases/leave-room.usecase';
+import { UpdateRoomSettingsUsecase } from '@/rooms/usecases/update-room-settings.usecase';
 import {
   Body,
   Controller,
   Get,
+  Param,
+  Patch,
   Post,
   Request,
   UseGuards,
@@ -26,6 +35,7 @@ import {
   ApiBadRequestResponse,
   ApiConflictResponse,
   ApiCreatedResponse,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -46,7 +56,8 @@ export class RoomsController {
     private readonly findMyRoomsUsecase: FindMyRoomsUsecase,
     private readonly createRoomUsecase: CreateRoomUsecase,
     private readonly inviteUserToRoomUsecase: InviteUserToRoomUsecase,
-    private readonly leaveRoomUsecase: LeaveRoomUsecase
+    private readonly leaveRoomUsecase: LeaveRoomUsecase,
+    private readonly updateRoomSettingsUsecase: UpdateRoomSettingsUsecase
   ) {}
 
   @Get('public')
@@ -108,5 +119,23 @@ export class RoomsController {
     @Body() leaveRoomRequestDto: LeaveRoomRequestDto
   ): Promise<RoomResponseDto> {
     return this.leaveRoomUsecase.execute(req.auth.userId, leaveRoomRequestDto);
+  }
+
+  @Patch('settings/:id')
+  @ApiClerkAuthHeaders()
+  @ApiOkResponse({ type: RoomResponseDto })
+  @ApiBadRequestResponse({ schema: NoRoomSettingsDefinedExceptionSchema })
+  @ApiForbiddenResponse({ schema: NotRoomOwnerExceptionSchema })
+  @ApiOperation({ description: 'Update room settings' })
+  updateRoomSettings(
+    @Request() req: Request,
+    @Param('id') roomId: string,
+    @Body() updateRoomSettingsRequestDto: UpdateRoomSettingsRequestDto
+  ): Promise<RoomResponseDto> {
+    return this.updateRoomSettingsUsecase.execute(
+      req.auth.userId,
+      roomId,
+      updateRoomSettingsRequestDto
+    );
   }
 }

--- a/packages/api/src/rooms/rooms.module.ts
+++ b/packages/api/src/rooms/rooms.module.ts
@@ -9,6 +9,7 @@ import { FindMyRoomsUsecase } from '@/rooms/usecases/find-my-rooms.usecase';
 import { FindPublicRoomsUsecase } from '@/rooms/usecases/find-public-rooms.usecase';
 import { InviteUserToRoomUsecase } from '@/rooms/usecases/invite-user-to-room.usecase';
 import { LeaveRoomUsecase } from '@/rooms/usecases/leave-room.usecase';
+import { UpdateRoomSettingsUsecase } from '@/rooms/usecases/update-room-settings.usecase';
 import { Module } from '@nestjs/common';
 
 @Module({
@@ -26,6 +27,7 @@ import { Module } from '@nestjs/common';
     FindMyRoomsUsecase,
     InviteUserToRoomUsecase,
     LeaveRoomUsecase,
+    UpdateRoomSettingsUsecase,
   ],
 })
 export class RoomsModule {}

--- a/packages/api/src/rooms/rooms.repository.ts
+++ b/packages/api/src/rooms/rooms.repository.ts
@@ -1,6 +1,7 @@
 import { DB_ROOM_MODEL_KEY } from '@/common/constants/models/room';
 import { Room } from '@/common/types/room';
 import { CreateRoomRequestDto } from '@/rooms/dtos/create-room.request.dto';
+import { UpdateRoomSettingsRequestDto } from '@/rooms/dtos/update-room-settings.request.dto';
 import { Inject, Injectable } from '@nestjs/common';
 import { Model } from 'mongoose';
 
@@ -39,6 +40,20 @@ export class RoomsRepository {
 
   async leaveRoom(userId: string, room: Room): Promise<Room> {
     room.members = room.members.filter((user) => user !== userId);
+    await room.save();
+    return room;
+  }
+
+  async updateRoomSettings(
+    updateRoomSettingsRequestDto: UpdateRoomSettingsRequestDto,
+    room: Room
+  ): Promise<Room> {
+    if (updateRoomSettingsRequestDto.name !== undefined) {
+      room.name = updateRoomSettingsRequestDto.name;
+    }
+    if (updateRoomSettingsRequestDto.private !== undefined) {
+      room.private = updateRoomSettingsRequestDto.private;
+    }
     await room.save();
     return room;
   }

--- a/packages/api/src/rooms/usecases/update-room-settings.usecase.ts
+++ b/packages/api/src/rooms/usecases/update-room-settings.usecase.ts
@@ -1,0 +1,43 @@
+import { ClerkAuthUserProvider } from '@/auth/providers/clerk/clerk-auth-user.provider';
+import { InternalServerErrorException } from '@/common/exceptions/internal-server-error.exception';
+import { UserNotFoundException } from '@/common/exceptions/user-not-found.exception';
+import { Usecase } from '@/common/types/usecase';
+import { RoomResponseSchema } from '@/contract/rooms/room.response.dto';
+import { InviteUserToRoomRequestDto } from '@/rooms/dtos/invite-user-to-room.request.dto';
+import { RoomResponseDto } from '@/rooms/dtos/room.response.dto';
+import { UpdateRoomSettingsRequestDto } from '@/rooms/dtos/update-room-settings.request.dto';
+import { NoRoomSettingsDefinedException } from '@/rooms/exceptions/no-room-settings-defined.exception';
+import { NotRoomOwnerException } from '@/rooms/exceptions/not-room-owner.exception';
+import { UserAlreadyInRoomException } from '@/rooms/exceptions/user-already-in-room.exception';
+import { RoomsRepository } from '@/rooms/rooms.repository';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UpdateRoomSettingsUsecase implements Usecase {
+  constructor(private readonly roomsRepository: RoomsRepository) {}
+
+  async execute(
+    userId: string,
+    roomId: string,
+    updateRoomSettingsRequestDto: UpdateRoomSettingsRequestDto
+  ): Promise<RoomResponseDto> {
+    const existingRoom = await this.roomsRepository.findRoom(roomId);
+    if (existingRoom.owner !== userId) {
+      throw new NotRoomOwnerException();
+    }
+
+    if (!Object.keys(updateRoomSettingsRequestDto).length) {
+      throw new NoRoomSettingsDefinedException();
+    }
+
+    try {
+      const room = await this.roomsRepository.updateRoomSettings(
+        updateRoomSettingsRequestDto,
+        existingRoom
+      );
+      return RoomResponseSchema.parse(room);
+    } catch (e) {
+      throw new InternalServerErrorException(e.message);
+    }
+  }
+}

--- a/packages/api/src/rooms/usecases/update-room-settings.usecase.ts
+++ b/packages/api/src/rooms/usecases/update-room-settings.usecase.ts
@@ -1,14 +1,10 @@
-import { ClerkAuthUserProvider } from '@/auth/providers/clerk/clerk-auth-user.provider';
 import { InternalServerErrorException } from '@/common/exceptions/internal-server-error.exception';
-import { UserNotFoundException } from '@/common/exceptions/user-not-found.exception';
 import { Usecase } from '@/common/types/usecase';
 import { RoomResponseSchema } from '@/contract/rooms/room.response.dto';
-import { InviteUserToRoomRequestDto } from '@/rooms/dtos/invite-user-to-room.request.dto';
 import { RoomResponseDto } from '@/rooms/dtos/room.response.dto';
 import { UpdateRoomSettingsRequestDto } from '@/rooms/dtos/update-room-settings.request.dto';
 import { NoRoomSettingsDefinedException } from '@/rooms/exceptions/no-room-settings-defined.exception';
 import { NotRoomOwnerException } from '@/rooms/exceptions/not-room-owner.exception';
-import { UserAlreadyInRoomException } from '@/rooms/exceptions/user-already-in-room.exception';
 import { RoomsRepository } from '@/rooms/rooms.repository';
 import { Injectable } from '@nestjs/common';
 

--- a/packages/contract/rooms/update-room-settings.request.dto.d.ts
+++ b/packages/contract/rooms/update-room-settings.request.dto.d.ts
@@ -1,0 +1,6 @@
+import { UpdateRoomSettingsRequestSchema } from "./update-room-settings.request.dto";
+import { z } from "zod";
+
+export type UpdateRoomSettingsRequestDto = z.infer<
+  typeof UpdateRoomSettingsRequestSchema
+>;

--- a/packages/contract/rooms/update-room-settings.request.dto.ts
+++ b/packages/contract/rooms/update-room-settings.request.dto.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const UpdateRoomSettingsRequestSchema = z.object({
+  name: z.string().optional(),
+  private: z.boolean().optional(),
+});


### PR DESCRIPTION
## summary

- Add update room settings controller, usecase and repository methods
- Only owners can update room settings
- The settings can be `name` and/or `private`, but never an empty object