### PR TITLE
feat: add message to chat

### DIFF
--- a/packages/api/src/chats/chats.controller.ts
+++ b/packages/api/src/chats/chats.controller.ts
@@ -1,23 +1,13 @@
 import { ClerkAuthGuard } from '@/auth/guards/clerk/clerk.auth.guard';
 import { ApiClerkAuthHeaders } from '@/auth/guards/clerk/open-api-clerk-headers.decorator';
-import { AddMessageToChatRequestDto } from '@/chats/dtos/add-message-to-chat.request.dto';
 import { ChatMessageResponseDto } from '@/chats/dtos/chat-message.response.dto';
 import { ChatResponseDto } from '@/chats/dtos/chat.response.dto';
-import { CreateChatForRoomRequestDto } from '@/chats/dtos/create-chat-for-room.request.dto';
 import { ChatNotFoundExceptionSchema } from '@/chats/exceptions/chat-not-found.exception';
 import { AddMessageToChatUsecase } from '@/chats/usecases/add-message-to-chat.usecase';
 import { CreateChatForRoomUsecase } from '@/chats/usecases/create-chat-for-room.usecase';
 import { FindChatByRoomIdUsecase } from '@/chats/usecases/find-chat-by-room-id.usecase';
 import { FindChatMessageHistoryByRoomIdUsecase } from '@/chats/usecases/find-chat-message-history-by-room-id.usecase';
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  Post,
-  Request,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
 import {
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -64,26 +54,5 @@ export class ChatsController {
       req.auth.userId,
       roomId
     );
-  }
-
-  @Post()
-  @ApiOkResponse({ type: ChatResponseDto })
-  @ApiClerkAuthHeaders()
-  createChat(
-    @Request() req: Request,
-    @Body() dto: CreateChatForRoomRequestDto
-  ): Promise<ChatResponseDto> {
-    return this.createChatForRoomUsecase.execute(req.auth.userId, dto);
-  }
-
-  @Post('add-message/:roomId')
-  @ApiOkResponse({ type: ChatResponseDto })
-  @ApiClerkAuthHeaders()
-  addMessageToChat(
-    @Request() req: Request,
-    @Param('roomId') roomId: string,
-    @Body() dto: AddMessageToChatRequestDto
-  ): Promise<ChatResponseDto> {
-    return this.addMessageToChatUsecase.execute(roomId, dto, req.auth.userId);
   }
 }

--- a/packages/api/src/chats/chats.controller.ts
+++ b/packages/api/src/chats/chats.controller.ts
@@ -3,8 +3,6 @@ import { ApiClerkAuthHeaders } from '@/auth/guards/clerk/open-api-clerk-headers.
 import { ChatMessageResponseDto } from '@/chats/dtos/chat-message.response.dto';
 import { ChatResponseDto } from '@/chats/dtos/chat.response.dto';
 import { ChatNotFoundExceptionSchema } from '@/chats/exceptions/chat-not-found.exception';
-import { AddMessageToChatUsecase } from '@/chats/usecases/add-message-to-chat.usecase';
-import { CreateChatForRoomUsecase } from '@/chats/usecases/create-chat-for-room.usecase';
 import { FindChatByRoomIdUsecase } from '@/chats/usecases/find-chat-by-room-id.usecase';
 import { FindChatMessageHistoryByRoomIdUsecase } from '@/chats/usecases/find-chat-message-history-by-room-id.usecase';
 import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
@@ -24,9 +22,7 @@ import {
 export class ChatsController {
   constructor(
     private readonly findChatByRoomIdUsecase: FindChatByRoomIdUsecase,
-    private readonly findChatMessageHistoryByRoomIdUsecase: FindChatMessageHistoryByRoomIdUsecase,
-    private readonly addMessageToChatUsecase: AddMessageToChatUsecase,
-    private readonly createChatForRoomUsecase: CreateChatForRoomUsecase
+    private readonly findChatMessageHistoryByRoomIdUsecase: FindChatMessageHistoryByRoomIdUsecase
   ) {}
 
   @Get(':roomId')

--- a/packages/api/src/chats/chats.module.ts
+++ b/packages/api/src/chats/chats.module.ts
@@ -3,6 +3,7 @@ import { ClerkAuthGuard } from '@/auth/guards/clerk/clerk.auth.guard';
 import { ChatsController } from '@/chats/chats.controller';
 import { chatsMongooseProviders } from '@/chats/chats.mongoose.providers';
 import { ChatsRepository } from '@/chats/chats.repository';
+import { AddMessageToChatUsecase } from '@/chats/usecases/add-message-to-chat.usecase';
 import { CreateChatForRoomUsecase } from '@/chats/usecases/create-chat-for-room.usecase';
 import { FindChatByRoomIdUsecase } from '@/chats/usecases/find-chat-by-room-id.usecase';
 import { FindChatMessageHistoryByRoomIdUsecase } from '@/chats/usecases/find-chat-message-history-by-room-id.usecase';
@@ -22,6 +23,7 @@ import { Module } from '@nestjs/common';
     FindChatByRoomIdUsecase,
     FindChatMessageHistoryByRoomIdUsecase,
     CreateChatForRoomUsecase,
+    AddMessageToChatUsecase,
   ],
 })
 export class ChatsModule {}

--- a/packages/api/src/chats/chats.repository.ts
+++ b/packages/api/src/chats/chats.repository.ts
@@ -1,5 +1,7 @@
+import { AddMessageToChatRequestDto } from '@/chats/dtos/add-message-to-chat.request.dto';
 import { CreateChatForRoomRequestDto } from '@/chats/dtos/create-chat-for-room.request.dto';
 import { DB_CHAT_MODEL_KEY } from '@/common/constants/models/chat';
+import { createChatMessageFactory } from '@/common/factories/create-chat-message.factory';
 import { Chat } from '@/common/types/chat';
 import { Inject, Injectable } from '@nestjs/common';
 import { Model } from 'mongoose';
@@ -23,6 +25,24 @@ export class ChatsRepository {
       participantIds: [],
       messageHistory: [],
     });
+    await chat.save();
+    return chat;
+  }
+
+  async addMessageToChat(
+    chat: Chat,
+    addMessageToChatRequestDto: AddMessageToChatRequestDto,
+    userId?: string
+  ): Promise<Chat> {
+    chat.messageHistory.push(
+      createChatMessageFactory(addMessageToChatRequestDto, userId)
+    );
+    if (
+      !addMessageToChatRequestDto.sender.isAi &&
+      !chat.participantIds.find((id) => userId === id)
+    ) {
+      chat.participantIds.push(userId);
+    }
     await chat.save();
     return chat;
   }

--- a/packages/api/src/chats/dtos/add-message-to-chat.request.dto.ts
+++ b/packages/api/src/chats/dtos/add-message-to-chat.request.dto.ts
@@ -1,0 +1,6 @@
+import { AddMessageToChatRequestSchema } from '@/contract/chats/add-message-to-chat.request.dto';
+import { createZodDto } from '@anatine/zod-nestjs';
+
+export class AddMessageToChatRequestDto extends createZodDto(
+  AddMessageToChatRequestSchema
+) {}

--- a/packages/api/src/chats/exceptions/chat-message-must-have-sender.exception.ts
+++ b/packages/api/src/chats/exceptions/chat-message-must-have-sender.exception.ts
@@ -1,0 +1,36 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export const ChatMessageMustHaveSenderExceptionSchema = {
+  type: 'object',
+  properties: {
+    statusCode: {
+      type: 'number',
+      example: 400,
+    },
+    message: {
+      type: 'array',
+      items: {
+        type: 'string',
+        example: 'chat_message: no_sender',
+      },
+    },
+    error: {
+      type: 'string',
+      example: 'Message must have a sender id',
+    },
+  },
+  required: ['statusCode', 'message', 'error'],
+};
+
+export class ChatMessageMustHaveSenderException extends HttpException {
+  constructor() {
+    super(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ['chat_message: no_sender'],
+        error: 'Message must have a sender id',
+      },
+      HttpStatus.BAD_REQUEST
+    );
+  }
+}

--- a/packages/api/src/chats/schemas/chat.mongoose.schema.ts
+++ b/packages/api/src/chats/schemas/chat.mongoose.schema.ts
@@ -1,50 +1,61 @@
 import * as mongoose from 'mongoose';
 
-export const MessageSchema = new mongoose.Schema(
+const MetaSchema = new mongoose.Schema(
   {
-    sender: {
+    tokens: {
+      type: Number,
+      required: true,
+    },
+    replyTo: {
+      type: String,
+      required: false,
+    },
+    ai: {
       type: {
-        userId: {
+        llmModel: {
           type: String,
-          required: false,
-        },
-        isAi: {
-          type: Boolean,
-          default: false,
           required: true,
         },
-        aiMeta: {
-          type: {
-            llmModel: {
-              type: String,
-              required: true,
-            },
-            tokens: {
-              type: Number,
-              required: true,
-            },
-            replyTo: {
-              type: mongoose.Schema.Types.ObjectId,
-              required: true,
-            },
-          },
-          required: false,
-        },
       },
+      _id: false,
+      required: false,
     },
-    content: {
+  },
+  { _id: false, required: true }
+);
+
+const SenderSchema = new mongoose.Schema(
+  {
+    userId: {
       type: String,
+      required: false,
+    },
+    isAi: {
+      type: Boolean,
+      default: false,
       required: true,
     },
   },
-  { timestamps: true }
+  { _id: false, required: true }
 );
+
+export const MessageSchema = new mongoose.Schema({
+  sender: SenderSchema,
+  content: {
+    type: String,
+    required: true,
+  },
+  meta: MetaSchema,
+  createdAt: {
+    type: Date,
+    required: true,
+  },
+});
 
 export const ChatSchema = new mongoose.Schema(
   {
     roomId: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'Room',
+      type: String,
       index: true,
       required: true,
     },

--- a/packages/api/src/chats/usecases/add-message-to-chat.usecase.ts
+++ b/packages/api/src/chats/usecases/add-message-to-chat.usecase.ts
@@ -1,0 +1,40 @@
+import { ChatsRepository } from '@/chats/chats.repository';
+import { AddMessageToChatRequestDto } from '@/chats/dtos/add-message-to-chat.request.dto';
+import { ChatResponseDto } from '@/chats/dtos/chat.response.dto';
+import { ChatMessageMustHaveSenderException } from '@/chats/exceptions/chat-message-must-have-sender.exception';
+import { ChatNotFoundException } from '@/chats/exceptions/chat-not-found.exception';
+import { InternalServerErrorException } from '@/common/exceptions/internal-server-error.exception';
+import { Usecase } from '@/common/types/usecase';
+import { ChatResponseSchema } from '@/contract/chats/chat.response.dto';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AddMessageToChatUsecase implements Usecase {
+  constructor(private readonly chatsRepository: ChatsRepository) {}
+
+  async execute(
+    roomId: string,
+    addMessageToChatRequestDto: AddMessageToChatRequestDto,
+    userId?: string
+  ): Promise<ChatResponseDto> {
+    const existingChat = await this.chatsRepository.findChatByRoomId(roomId);
+    if (!existingChat) {
+      throw new ChatNotFoundException();
+    }
+
+    if (!addMessageToChatRequestDto.sender.isAi && !userId) {
+      throw new ChatMessageMustHaveSenderException();
+    }
+
+    try {
+      const chat = await this.chatsRepository.addMessageToChat(
+        existingChat,
+        addMessageToChatRequestDto,
+        userId
+      );
+      return ChatResponseSchema.parse(chat);
+    } catch (e) {
+      throw new InternalServerErrorException(e.message);
+    }
+  }
+}

--- a/packages/api/src/chats/usecases/create-chat-for-room.usecase.ts
+++ b/packages/api/src/chats/usecases/create-chat-for-room.usecase.ts
@@ -25,10 +25,7 @@ export class CreateChatForRoomUsecase implements Usecase {
       const chat = await this.chatsRepository.createChatForRoom(
         createChatForRoomRequestDto
       );
-      return ChatResponseSchema.parse({
-        ...chat,
-        roomId: chat.roomId.toString(),
-      });
+      return ChatResponseSchema.parse(chat);
     } catch (e) {
       throw new InternalServerErrorException(e.message);
     }

--- a/packages/api/src/common/factories/create-chat-message.factory.ts
+++ b/packages/api/src/common/factories/create-chat-message.factory.ts
@@ -1,0 +1,29 @@
+import { AddMessageToChatRequestDto } from '@/chats/dtos/add-message-to-chat.request.dto';
+import { ChatMessage } from '@/common/types/chat';
+
+export function createChatMessageFactory(
+  addMessageToChatRequestDto: AddMessageToChatRequestDto,
+  userId?: string
+): Omit<ChatMessage, 'id'> {
+  const { sender, content, meta } = addMessageToChatRequestDto;
+
+  return {
+    sender: {
+      ...(userId ? { userId } : {}),
+      isAi: sender.isAi,
+    },
+    content,
+    meta: {
+      tokens: meta.tokens,
+      ...(meta.replyTo ? { replyTo: meta.replyTo } : {}),
+      ...(meta.ai
+        ? {
+            ai: {
+              llmModel: meta.ai.llmModel,
+            },
+          }
+        : {}),
+    },
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/packages/api/src/common/types/chat.ts
+++ b/packages/api/src/common/types/chat.ts
@@ -2,28 +2,31 @@ import { Document } from 'mongoose';
 
 export interface AiMeta {
   llmModel: string;
+}
+
+export interface Meta {
   tokens: number;
-  replyTo: string;
+  replyTo?: string;
+  ai?: AiMeta;
 }
 
 export interface Sender {
-  userId: string;
+  userId?: string;
   isAi: boolean;
-  aiMeta?: AiMeta;
 }
 
-export interface Message {
-  readonly id: string;
+export interface ChatMessage {
+  readonly id?: string;
   sender: Sender;
   content: string;
+  meta: Meta;
   readonly createdAt: string;
-  readonly updatedAt: string;
 }
 
 export interface Chat extends Document {
   readonly id: string;
   roomId: string;
-  messageHistory: Message[];
+  messageHistory: ChatMessage[];
   participantIds: string[];
   readonly createdAt: string;
   readonly updatedAt: string;

--- a/packages/contract/chats/add-message-to-chat.request.dto.d.ts
+++ b/packages/contract/chats/add-message-to-chat.request.dto.d.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { AddMessageToChatRequestSchema } from './add-message-to-chat.request.dto';
+
+export type AddMessageToChatRequestDto = z.infer<
+  typeof AddMessageToChatRequestSchema
+>;

--- a/packages/contract/chats/add-message-to-chat.request.dto.ts
+++ b/packages/contract/chats/add-message-to-chat.request.dto.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
-export const ChatMessageResponseSchema = z.object({
-  id: z.string(),
+export const AddMessageToChatRequestSchema = z.object({
   sender: z.object({
-    userId: z.string().optional(),
     isAi: z.boolean(),
   }),
   content: z.string(),
@@ -16,5 +14,4 @@ export const ChatMessageResponseSchema = z.object({
       })
       .optional(),
   }),
-  createdAt: z.date(),
 });

--- a/packages/contract/chats/chat.response.dto.ts
+++ b/packages/contract/chats/chat.response.dto.ts
@@ -1,14 +1,9 @@
 import { ChatMessageResponseSchema } from "./chat-message.response.dto";
-import { ObjectId } from "mongodb";
 import { z } from "zod";
-
-const zObjectIdString = z
-  .unknown()
-  .transform((objectId: ObjectId) => objectId.toString());
 
 export const ChatResponseSchema = z.object({
   id: z.string(),
-  roomId: zObjectIdString,
+  roomId: z.string(),
   messageHistory: z.array(ChatMessageResponseSchema),
   participantIds: z.array(z.string()),
   createdAt: z.date(),


### PR DESCRIPTION
## Summary

- Add message to chat services
- If a `Message` is not AI originated, then a `Sender` must be defined
- A `Message` always has an `id` and when a `Message` is in response to another one, a reference to the `id` of that `Message` is stored
- `Tokens` used by a message are always stored in `meta`
- This `usecase` is to be used for now in the socket service, so no controller endpoint is available
- Reference ids are stored as `string`s in the database due to a limitation of `zod` and `swagger UI`. To allow schema parses as they have been until now, storage was simplified: `ObjectId --> string`

## DB records example

<img width="428" alt="image" src="https://github.com/xgeekshq/intelli-mate/assets/5495320/311babd1-9d38-4a27-8c58-2cf1702329d0">
