### PR TITLE
feat: improve returning to chat from settings page

### DIFF
--- a/packages/web-ui/components/room-header.tsx
+++ b/packages/web-ui/components/room-header.tsx
@@ -2,9 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Settings } from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
+import { ArrowLeft, Settings } from 'lucide-react';
 
 interface RoomHeaderProps {
   id: string;
@@ -18,14 +16,21 @@ export function RoomHeader({ id, name }: RoomHeaderProps) {
   const isSettingsPage = pathname.includes('settings');
   return (
     <div className="flex min-h-[41px] w-full items-center justify-between border-b px-4">
-      <p className="relative text-lg font-semibold tracking-tight">
+      <p className="text-lg font-semibold tracking-tight">
         {isSettingsPage ? `${name} | settings` : name}
       </p>
+      {isSettingsPage && (
+        <Link
+          href={`/rooms/${id}`}
+          className="flex items-center gap-1 font-semibold tracking-tight"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          back to chat
+        </Link>
+      )}
       {!isSettingsPage && (
         <Link href={`${id}/settings`}>
-          <Button variant="ghost">
-            <Settings className="h-5 w-5" />
-          </Button>
+          <Settings className="h-5 w-5" />
         </Link>
       )}
     </div>

--- a/packages/web-ui/components/site-header.tsx
+++ b/packages/web-ui/components/site-header.tsx
@@ -9,8 +9,8 @@ import { ThemeToggle } from '@/components/theme-toggle';
 
 export function SiteHeader() {
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-background">
-      <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
+    <header className="bg-background sticky top-0 z-40 w-full border-b px-4">
+      <div className="flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
         <MainNav />
         <div className="flex flex-1 items-center justify-end space-x-4">
           <nav className="flex items-center gap-1">


### PR DESCRIPTION
Feature: a new feature

- Add a redirect button to go back to the previous chat from the settings page
- Align the header with the application layout

## Screenshots
![image](https://github.com/xgeekshq/intelli-mate/assets/95644495/76bae008-ce66-4dca-9bed-2a1aeab9724c)
