### PR TITLE
fix: replace getUserList method

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@anatine/zod-nestjs": "^1.10.0",
-    "@clerk/clerk-sdk-node": "4.10.5",
+    "@clerk/clerk-sdk-node": "^4.12.1",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.2",
     "@nestjs/core": "^9.0.0",

--- a/packages/api/src/auth/providers/clerk/clerk-auth-user.provider.ts
+++ b/packages/api/src/auth/providers/clerk/clerk-auth-user.provider.ts
@@ -15,9 +15,9 @@ export class ClerkAuthUserProvider implements AuthProvider {
 
   async findUser(id: string): Promise<User | undefined> {
     const userRoles = await this.authRepository.findUserRolesForSingleUser(id);
-    const userList = await users.getUserList();
+    const user = await users.getUser(id);
     return {
-      ...userList.find((u) => u.id === id),
+      ...user,
       roles: userRoles.roles,
     };
   }


### PR DESCRIPTION
**What type of PR is this?**

Fix: A bug fix

**What this PR does / why we need it:**

- Upgrade `clerk`
- Replace method `getUserList` with `getUser`

The application is failing in the `AuthController.findUser` method and it calls 2 functions. 

The schema fails in every field except the `roles` which means the `this.authRepository.findUserRolesForSingleUser(id)` successfully retrieves the role.

This leads us to have a problem in the `getUserList`. With this PR, I intend to understand if the problem is the method or if some users are being deleted (?) from the clerk. 

**Which issue(s) this PR fixes:**

Fixes [#83](https://github.com/xgeekshq/intelli-mate/issues/83)

**Special notes for your reviewer:**

If this doesn't fix the bug, a deeper investigation into the integration with `clerk` is needed.

Errors:

```

[Nest] 1  - 07/25/2023, 2:22:45 PM   ERROR [ExceptionsHandler] [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "id"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "primaryEmailAddressId"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "profileImageUrl"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "username"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "firstName"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "lastName"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "array",
    "received": "undefined",
    "path": [
      "emailAddresses"
    ],
    "message": "Required"
  }
]
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "id"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "primaryEmailAddressId"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "profileImageUrl"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "username"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "firstName"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "lastName"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "array",
    "received": "undefined",
    "path": [
      "emailAddresses"
    ],
    "message": "Required"
  }
]
    at get error [as error] (/app/contract/node_modules/zod/lib/types.js:43:31)
    at ZodObject.parse (/app/contract/node_modules/zod/lib/types.js:141:22)
    at AuthController.findUser (/app/api/src/auth/auth.controller.js:32:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /app/api/node_modules/@nestjs/core/router/router-execution-context.js:46:28
    at async /app/api/node_modules/@nestjs/core/router/router-proxy.js:9:17
```