### PR TITLE
fix: summary can be undefined

### DIFF
--- a/packages/api/src/ai/services/ai.service.ts
+++ b/packages/api/src/ai/services/ai.service.ts
@@ -30,10 +30,11 @@ export class AiService {
         console.log(e);
       }
     }
+
     const chain = this.chainService.getChain(
       chatId,
       this.llmModel,
-      summary.response
+      summary?.response
     );
 
     try {


### PR DESCRIPTION
**What type of PR is this?**

Fix: A bug fix

**What this PR does / why we need it:**

- Prevents the application from accessing the `response` if the `summary` is undefined

