### PR TITLE
fix: remove credentials from socket configuration

### DIFF
--- a/packages/api/src/chats/chat-socket.gateway.ts
+++ b/packages/api/src/chats/chat-socket.gateway.ts
@@ -18,7 +18,6 @@ import { Server, Socket } from 'socket.io';
 @WebSocketGateway({
   cors: {
     origin: '*',
-    credentials: true,
   },
 })
 export class ChatSocketGateway {

--- a/packages/web-ui/app/state/socket.ts
+++ b/packages/web-ui/app/state/socket.ts
@@ -2,9 +2,7 @@ import { atom } from 'recoil';
 import io, { Socket } from 'socket.io-client';
 
 // @ts-ignore
-const socket = io(process.env.NEXT_PUBLIC_SOCKET_URL, {
-  withCredentials: true,
-});
+const socket = io(process.env.NEXT_PUBLIC_SOCKET_URL);
 
 export const socketState = atom<Socket>({
   key: 'Socket',


### PR DESCRIPTION
**What type of PR is this?**

Fix: A bug fix


**What this PR does / why we need it:**
Remove credentials in socket configuration, with credential the CORS don't allow `*` as the origin
