### PR TITLE
fix: add the exact route to socket cors origin

### DIFF
--- a/packages/api/src/chats/adapters/redis-io.adapter.ts
+++ b/packages/api/src/chats/adapters/redis-io.adapter.ts
@@ -23,6 +23,7 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   createIOServer(port: number, options?: ServerOptions): any {
+    options.cors = { origin: this.configService.get('FRONTEND_ORIGIN_URL') };
     const server = super.createIOServer(port, options);
     server.adapter(this.adapterConstructor);
     return server;

--- a/packages/api/src/chats/chat-socket.gateway.ts
+++ b/packages/api/src/chats/chat-socket.gateway.ts
@@ -17,7 +17,7 @@ import { Server, Socket } from 'socket.io';
 
 @WebSocketGateway({
   cors: {
-    origin: '*',
+    credentials: true,
   },
 })
 export class ChatSocketGateway {


### PR DESCRIPTION
**What type of PR is this?**

Fix: A bug fix

**What this PR does / why we need it:**
Add exact route to frontend to avoid cors error with sockets