### PR TITLE
feat: use cacheClient instead of create a new redis client

### DIFF
--- a/helm/intelli-mate-api/values.yaml
+++ b/helm/intelli-mate-api/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: ghcr.io/xgeekshq/intelli-mate/api

--- a/packages/api/src/chats/adapters/redis-io.adapter.ts
+++ b/packages/api/src/chats/adapters/redis-io.adapter.ts
@@ -1,23 +1,23 @@
 import { ConfigService } from '@nestjs/config';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
-import { createClient } from 'redis';
 import { ServerOptions } from 'socket.io';
 
 export class RedisIoAdapter extends IoAdapter {
-  constructor(app, private readonly configService: ConfigService) {
+  constructor(
+    app,
+    private readonly configService: ConfigService,
+    private readonly cacheClient
+  ) {
     super(app);
   }
   private adapterConstructor: ReturnType<typeof createAdapter>;
 
   async connectToRedis(): Promise<void> {
-    const pubClient = createClient({
-      url: `redis://${this.configService.get('REDIS_CONNECTION_URL')}`,
-      password: this.configService.get('REDIS_HOST_PASSWORD'),
-    });
+    const pubClient = this.cacheClient;
     const subClient = pubClient.duplicate();
 
-    await Promise.all([pubClient.connect(), subClient.connect()]);
+    await subClient.connect();
 
     this.adapterConstructor = createAdapter(pubClient, subClient);
   }

--- a/packages/api/src/chats/adapters/redis-io.adapter.ts
+++ b/packages/api/src/chats/adapters/redis-io.adapter.ts
@@ -1,13 +1,15 @@
+import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
+import { RedisClientType } from 'redis';
 import { ServerOptions } from 'socket.io';
 
 export class RedisIoAdapter extends IoAdapter {
   constructor(
-    app,
+    app: INestApplication,
     private readonly configService: ConfigService,
-    private readonly cacheClient
+    private readonly cacheClient: RedisClientType
   ) {
     super(app);
   }

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,3 +1,4 @@
+import { CACHE_CLIENT } from '@/common/constants/cache';
 import { ZodValidationPipe } from '@anatine/zod-nestjs';
 import { VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -11,6 +12,7 @@ import { RedisIoAdapter } from './chats/adapters/redis-io.adapter';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
+  const cacheClient = app.get(CACHE_CLIENT);
 
   app.setGlobalPrefix('api');
   app.enableVersioning({
@@ -32,7 +34,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
 
-  const redisIoAdapter = new RedisIoAdapter(app, configService);
+  const redisIoAdapter = new RedisIoAdapter(app, configService, cacheClient);
   await redisIoAdapter.connectToRedis();
   app.useWebSocketAdapter(redisIoAdapter);
 


### PR DESCRIPTION
**What type of PR is this?**
Feature: a new feature


**What this PR does / why we need it:**
- change the redisIoAdapter to use an existing cacheClient Redis connection instead of creating a new RedisClient connection.
- Increase the number of API replicas created on deploy. (This change should be reverted after the RedisAdapter tests)
