### PR TITLE
fix: remove the limit of documents per chat and restrict csv documents

### DIFF
--- a/packages/api/config/default.json
+++ b/packages/api/config/default.json
@@ -5,9 +5,6 @@
     "defaultTokenLimitForSummarization": 14500,
     "defaultAiModel": "gpt-3.5-turbo-16k"
   },
-  "chat": {
-    "maxNumberOfDocumentsPerChat": 2
-  },
   "authorization": {
     "roles": [
       "Admin",

--- a/packages/api/src/app-config/app-config.service.ts
+++ b/packages/api/src/app-config/app-config.service.ts
@@ -2,12 +2,7 @@ import { AppConfigNotFoundException } from '@/app-config/exceptions/app-config-n
 import { Injectable } from '@nestjs/common';
 import * as appConfig from 'config';
 
-import {
-  ai as aiAppConfig,
-  chat as chatAppConfig,
-} from '../../config/default.json';
-
-type ChatAppConfig = typeof chatAppConfig;
+import { ai as aiAppConfig } from '../../config/default.json';
 
 type AiAppConfig = typeof aiAppConfig;
 
@@ -20,15 +15,6 @@ export class AppConfigService {
 
     return appConfig.get<AiAppConfig>('ai');
   }
-
-  getChatConfig(): ChatAppConfig {
-    if (!appConfig.has('chat')) {
-      throw new AppConfigNotFoundException();
-    }
-
-    return appConfig.get<ChatAppConfig>('chat');
-  }
-
   async getAppRoles(): Promise<string[]> {
     if (!appConfig.has('authorization.roles')) {
       throw new AppConfigNotFoundException();

--- a/packages/api/src/chats/chats.controller.ts
+++ b/packages/api/src/chats/chats.controller.ts
@@ -8,7 +8,6 @@ import { ChatNotFoundExceptionSchema } from '@/chats/exceptions/chat-not-found.e
 import { DocumentNotFoundExceptionSchema } from '@/chats/exceptions/document-not-found.exception';
 import { DocumentPermissionsMismatchExceptionSchema } from '@/chats/exceptions/document-permissions-mismatch.exception';
 import { MaxDocumentSizeLimitExceptionSchema } from '@/chats/exceptions/max-document-size-limit.exception';
-import { NoMoreDocumentsCanBeUploadedToChatExceptionSchema } from '@/chats/exceptions/no-more-documents-can-be-uploaded-to-chat.exception';
 import { FindChatByRoomIdUsecase } from '@/chats/usecases/find-chat-by-room-id.usecase';
 import { FindChatMessageHistoryByRoomIdUsecase } from '@/chats/usecases/find-chat-message-history-by-room-id.usecase';
 import { RemoveDocumentFromChatUsecase } from '@/chats/usecases/remove-document-from-chat.usecase';
@@ -35,13 +34,12 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { FilesInterceptor } from '@nestjs/platform-express';
+import { AnyFilesInterceptor } from '@nestjs/platform-express';
 import {
   ApiBadRequestResponse,
   ApiBody,
   ApiConflictResponse,
   ApiConsumes,
-  ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -110,7 +108,7 @@ export class ChatsController {
   @Post(':roomId/upload-documents')
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseInterceptors(
-    FilesInterceptor('files', 2, {
+    AnyFilesInterceptor({
       storage: diskStorage({
         destination: (req, file, cb) => {
           const uploadPath = `${chatDocumentsFolder()}/${req.params.roomId}`;
@@ -148,9 +146,6 @@ export class ChatsController {
   @ApiNoContentResponse({ description: 'No content' })
   @ApiBadRequestResponse({ schema: MaxDocumentSizeLimitExceptionSchema })
   @ApiConflictResponse({ schema: DocumentPermissionsMismatchExceptionSchema })
-  @ApiForbiddenResponse({
-    schema: NoMoreDocumentsCanBeUploadedToChatExceptionSchema,
-  })
   @ApiNotFoundResponse({ schema: ChatNotFoundExceptionSchema })
   @ApiOperation({ description: 'Upload documents into a chat' })
   uploadDocumentsToChat(

--- a/packages/api/src/chats/job-consumers/transform-doc-to-vector.job-consumer.ts
+++ b/packages/api/src/chats/job-consumers/transform-doc-to-vector.job-consumer.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'fs';
 import { AiService } from '@/ai/facades/ai.service';
 import { ChatsRepository } from '@/chats/chats.repository';
 import {
-  CSV_MIMETYPE,
   DOCX_MIMETYPE,
   PDF_MIMETYPE,
   TEXT_MIMETYPE,
@@ -20,7 +19,6 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Job } from 'bull';
 import { Document } from 'langchain/document';
 import { BaseDocumentLoader } from 'langchain/document_loaders';
-import { CSVLoader } from 'langchain/document_loaders/fs/csv';
 import { DocxLoader } from 'langchain/document_loaders/fs/docx';
 import { PDFLoader } from 'langchain/document_loaders/fs/pdf';
 import { TextLoader } from 'langchain/document_loaders/fs/text';
@@ -110,9 +108,6 @@ export class TransformDocToVectorJobConsumer {
 
     if (document.meta.mimetype === PDF_MIMETYPE) {
       loader = new PDFLoader(documentBlob);
-    }
-    if (document.meta.mimetype === CSV_MIMETYPE) {
-      loader = new CSVLoader(documentBlob);
     }
     if (document.meta.mimetype === TEXT_MIMETYPE) {
       loader = new TextLoader(documentBlob);

--- a/packages/api/src/common/constants/files.ts
+++ b/packages/api/src/common/constants/files.ts
@@ -3,17 +3,15 @@ import * as process from 'process';
 export const ACCEPTED_FILE_SIZE_LIMIT = 16_000_000;
 
 export const ACCEPTED_FILE_MIMETYPES_REGEXP =
-  /^(application\/pdf|text\/csv|text\/plain|application\/vnd\.openxmlformats-officedocument\.wordprocessingml\.document)$/;
+  /^(application\/pdf|text\/plain|application\/vnd\.openxmlformats-officedocument\.wordprocessingml\.document)$/;
 
 export const PDF_MIMETYPE = 'application/pdf';
-export const CSV_MIMETYPE = 'text/csv';
 export const TEXT_MIMETYPE = 'text/plain';
 export const DOCX_MIMETYPE =
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
 export const acceptedFileMimetypes = [
   PDF_MIMETYPE,
-  CSV_MIMETYPE,
   TEXT_MIMETYPE,
   DOCX_MIMETYPE,
 ];

--- a/packages/contract/chats/upload-documents.request.dto.ts
+++ b/packages/contract/chats/upload-documents.request.dto.ts
@@ -2,17 +2,11 @@ import { z } from "zod";
 
 const ACCEPTED_FILE_SIZE_LIMIT = 16_000_000;
 const PDF_MIMETYPE = "application/pdf";
-const CSV_MIMETYPE = "text/csv";
 const TEXT_MIMETYPE = "text/plain";
 const DOCX_MIMETYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-const ACCEPTED_FILE_MIMETYPES = [
-  PDF_MIMETYPE,
-  CSV_MIMETYPE,
-  TEXT_MIMETYPE,
-  DOCX_MIMETYPE,
-];
+const ACCEPTED_FILE_MIMETYPES = [PDF_MIMETYPE, TEXT_MIMETYPE, DOCX_MIMETYPE];
 export const UploadDocumentsRequestSchema = z.object({
   fileRoles: z.array(z.string()).refine((value) => value.some((item) => item), {
     message: "You have to select at least one role.",
@@ -21,7 +15,6 @@ export const UploadDocumentsRequestSchema = z.object({
   files: z
     .instanceof(FileList)
     .refine((files) => files.length > 0, "At least one file is required.")
-    .refine((files) => files.length <= 2, "You can only upload 2 files.")
     .refine(
       (files) =>
         Array.from(files).reduce((size, file) => size + file.size, 0) <
@@ -33,6 +26,6 @@ export const UploadDocumentsRequestSchema = z.object({
         Array.from(files).every((file) =>
           ACCEPTED_FILE_MIMETYPES.includes(file.type)
         ),
-      "Invalid file type, please insert a file with one of the next types: pdf, csv, txt or a word document."
+      "Invalid file type, please insert a file with one of the next types: pdf, txt or a word document."
     ),
 });

--- a/packages/web-ui/components/chat-tools.tsx
+++ b/packages/web-ui/components/chat-tools.tsx
@@ -88,8 +88,8 @@ export function ChatTools({ documents, roomId, isOwner }: ChatToolsProps) {
                 {documents?.map((document) => (
                   <HoverCard key={document.meta.filename}>
                     <HoverCardTrigger className="flex items-center justify-between rounded-md p-2 hover:bg-accent hover:text-accent-foreground">
-                      <div>
-                        <p className=" text-gray-500">
+                      <div className="max-w-[140px] truncate">
+                        <p className="text-gray-500">
                           {document.meta.vectorDBDocumentName}
                         </p>
                         <p>{document.meta.filename}</p>


### PR DESCRIPTION
**What type of PR is this?**
Fix: Fix problems with CSV files

**What this PR does / why we need it:**

- Restrict CSV files
- Remove the max number of filers per chat

