### PR TITLE
fix: protect the room name update to empty spaces

### DIFF
--- a/packages/contract/rooms/update-room-settings.request.dto.ts
+++ b/packages/contract/rooms/update-room-settings.request.dto.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
 export const UpdateRoomSettingsRequestSchema = z.object({
-  name: z.string().optional(),
+  name: z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length >= 3, {
+      message: "Name must have at least 3 characters",
+    })
+    .refine((value) => value.length <= 50, {
+      message: "Name must have at most 50 characters",
+    }),
   isPrivate: z.boolean().optional(),
 });


### PR DESCRIPTION
**What type of PR is this?**
Feature: a new feature
Fix: A bug fix


**What this PR does / why we need it:**
- Add the same validation to update the room name as the create room validations

**Which issue(s) this PR fixes:**


Fixes [#174](https://github.com/xgeekshq/intelli-mate/issues/174)