### PR TITLE
feat: display document sources

### DIFF
--- a/packages/web-ui/components/document-snippets.tsx
+++ b/packages/web-ui/components/document-snippets.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { ChatMessageSourceType } from '@/types/chat';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+type DocumentSnippetsProps = {
+  source: ChatMessageSourceType;
+};
+
+export function DocumentSnippets({ source }: DocumentSnippetsProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <p className="cursor-pointer text-sm text-gray-500 underline">
+          {source.filename}
+        </p>
+      </DialogTrigger>
+      <DialogContent className="overflow-y-scroll sm:max-h-[650px] sm:max-w-[900px]">
+        <DialogHeader>
+          <DialogTitle>
+            This answer was based on the following snippets
+          </DialogTitle>
+        </DialogHeader>
+        <>
+          {source.snippets.map((snippet, index) => {
+            return <p key={index}>{snippet}</p>;
+          })}
+        </>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web-ui/components/message.tsx
+++ b/packages/web-ui/components/message.tsx
@@ -7,6 +7,7 @@ import { format } from 'date-fns';
 
 import { ChatMessageType } from '@/types/chat';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
+import { DocumentSnippets } from '@/components/document-snippets';
 import Markdown from '@/components/markdown';
 
 export interface MessageProps {
@@ -31,11 +32,21 @@ const Message = memo(function Message({ message }: MessageProps) {
         <Markdown content={message.content} />
       </div>
       {message.response ? (
-        <div className="mt-4 flex gap-2 border-t bg-gray-50 p-4 dark:bg-gray-900">
-          <Avatar className="h-8 w-8 rounded-none">
-            <AvatarImage src={'/ai.png'} alt="AI Image" />
-          </Avatar>
-          <Markdown content={message.response} />
+        <div className="mt-4 flex flex-col gap-2 border-t bg-gray-50 p-4 dark:bg-gray-900">
+          <div className="flex gap-2">
+            <Avatar className="h-8 w-8 rounded-none">
+              <AvatarImage src={'/ai.png'} alt="AI Image" />
+            </Avatar>
+            <Markdown content={message.response} />
+          </div>
+          {message.source && (
+            <div className="flex justify-end">
+              <p className="text-sm text-gray-500">
+                Answer based on the following document:&nbsp;
+              </p>
+              <DocumentSnippets source={message.source} />
+            </div>
+          )}
         </div>
       ) : (
         <div className="relative mx-4 h-8 w-8">


### PR DESCRIPTION
**What type of PR is this?**
Feature: a new feature

**What this PR does / why we need it:**

- Display the document sources of an answer

**Demo**
<img width="816" alt="image" src="https://github.com/xgeekshq/intelli-mate/assets/95644495/dcacbd8b-a0bc-49cd-b62c-e447c1644a77">

<img width="968" alt="image" src="https://github.com/xgeekshq/intelli-mate/assets/95644495/934b1509-3d00-4bf5-ab1a-e3b055ce391f">

<img width="824" alt="image" src="https://github.com/xgeekshq/intelli-mate/assets/95644495/d244f099-b28e-4673-a3bc-b4d6fdc7b54f">

<img width="937" alt="image" src="https://github.com/xgeekshq/intelli-mate/assets/95644495/75c4ddc0-7e69-490c-a276-6063387ed5e9">
